### PR TITLE
Adding unit tests to prove that the keys pattern doesn't work

### DIFF
--- a/src/Falcor.Tests/Server/Routing/ParserTests.cs
+++ b/src/Falcor.Tests/Server/Routing/ParserTests.cs
@@ -165,7 +165,11 @@ namespace Falcor.Tests.Server.Routing
 
             var path7 = @"[""genrelist"", [0,1,2], ""name""]";
             var path7Expected = Path("genrelist", new NumericSet(0, 1, 2), "name");
-            Assert.Equal(path6Expected, path6parsed);
+
+			var path8 = @"[""genrelist"", [""51f2928f34"",""a32e8912f34""], ""name""]";
+			var path8Expected = Path("genrelist", new KeySet("51f2928f34", "a32e8912f34"), "name");
+
+			Assert.Equal(path6Expected, path6parsed);
 
 
             new List<PathParsingTest>
@@ -176,7 +180,8 @@ namespace Falcor.Tests.Server.Routing
                 Paths(path4).ShouldEqual(path4Expected),
                 Paths(path5).ShouldEqual(path5Expected),
                 Paths(path7).ShouldEqual(path7Expected),
-                Paths(path1, path2, path3).ShouldEqual(path1Expected, path2Expected, path3Expected),
+				Paths(path8).ShouldEqual(path8Expected),
+				Paths(path1, path2, path3).ShouldEqual(path1Expected, path2Expected, path3Expected),
                 Paths(path4, path1, path2, path3)
                     .ShouldEqual(path4Expected, path1Expected, path2Expected, path3Expected)
             }.ForEach(test =>

--- a/src/Falcor.Tests/Server/Routing/TestFalcorRouter.cs
+++ b/src/Falcor.Tests/Server/Routing/TestFalcorRouter.cs
@@ -18,7 +18,13 @@ namespace Falcor.Tests.Server.Routing
             };
 
             Get["foo"] = parameters => Complete(new PathValue(new FalcorPath("foo"), "bar"));
-        }
+
+			Get["foo[{keys:ids}].name"] = parameters => {
+				KeySet ids = parameters.ids;
+				var results = ids.Select(id => new PathValue(FalcorPath.From("foo", id, "name"), "Jill-" + id));
+				return Complete(results);
+			};
+		}
 
         // Test helper methods
         public static Task<RouteHandlerResult> Complete(params PathValue[] values) => Complete(values.ToList());


### PR DESCRIPTION
- bug #10

If I were to guess, I think the double quotes are killing the regex pattern. Here is an example from the client. I don't have a fix yet, but I wanted to show you the issue that I was having. If you give me some guidance, I can try and put together a fix.

Broken
`[["genrelist",["51f2928f34","a32e8912f34"],"name"]]`

Works (numericset)
`[["genrelist",[1,2],"name"]]`
